### PR TITLE
Name Updated From "ietians-diary" to "Ietians Diary"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">ietians-diary</string>
+    <string name="app_name">Ietians Diary</string>
     <string name="sign_in_hero_text">Let\'s get you started,\n Sign in below to continue.</string>
     <string name="button_text">Sign In with Google</string>
     <string name="terms_and_conditions_1">*By signing in you agree to our </string>


### PR DESCRIPTION
## What was the Issue  #62 ?
The app_name was "ietians-diary" in the AndroidManifest.xml , it should be "Ietians Diary"

##  What does this PR do ?
This PR changes the string tag's text content from "ietians-diary" to "Ietians Diary" , Which is inside the strings.xml and fixes #62 
